### PR TITLE
URL rotation fixes

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -243,6 +243,7 @@ def test_text_urls():
                     (a for a in annots if a.A.URI == f'{test_url}{fragment}'),
                     None)
                 assert annot is not None
+                assert getattr(annot, 'QuadPoints', None) is None
                 # Positions in points (72 per inch.)
                 assert annot.Rect[1] == decimal.Decimal(y) * 72
 
@@ -252,8 +253,8 @@ def test_text_rotated_urls():
 
     test_url = 'https://test_text_urls.matplotlib.org/'
 
-    fig = plt.figure(figsize=(2, 1))
-    fig.text(0.1, 0.1, 'test plain 123', rotation=45, url=f'{test_url}')
+    fig = plt.figure(figsize=(1, 1))
+    fig.text(0.1, 0.1, 'N', rotation=45, url=f'{test_url}')
 
     with io.BytesIO() as fd:
         fig.savefig(fd, format='pdf')
@@ -267,12 +268,9 @@ def test_text_rotated_urls():
                 (a for a in annots if a.A.URI == f'{test_url}'),
                 None)
             assert annot is not None
-            # Positions in points (72 per inch.) Figure is 2 inches
-            assert annot.QuadPoint[0][0] / 72 / 2 ==  \
-                pytest.approx(decimal.Decimal('0.1'), abs=1e-1)
-            assert annot.QuadPoint[1][0] / 72 / 2 == \
-                pytest.approx(decimal.Decimal('0.08'), abs=1e-1)
-            assert annot.Rect[0] == annot.QuadPoint[1][0]
+            assert getattr(annot, 'QuadPoints', None) is not None
+            # Positions in points (72 per inch)
+            assert annot.Rect[0] == annot.QuadPoints[6] - decimal.Decimal('0.00001')
 
 
 @needs_usetex


### PR DESCRIPTION
## PR Summary

When trying out the changes manually I found a number of things that was simpler to fix directly than to comment...

I think that if you merge this it should show up in the Matplotlib PR as well.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
